### PR TITLE
Upgraded to lock.js v10.11

### DIFF
--- a/index.tpl.html
+++ b/index.tpl.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-    <script src="//cdn.auth0.com/js/lock/10.6/lock.min.js"></script>
+    <script src="//cdn.auth0.com/js/lock/10.11.0/lock.min.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/component.js
+++ b/src/component.js
@@ -23,7 +23,7 @@ class AuthComponent extends React.Component {
       );
 
       this.lock.on('authenticated', (authResult) => {
-        this.lock.getProfile(authResult.idToken, (error, profile) => {
+        this.lock.getUserInfo(authResult.accessToken, (error, profile) => {
           if (error) {
             // Handle error
             console.error(error);
@@ -31,7 +31,7 @@ class AuthComponent extends React.Component {
           }
 
           const method = this.props.signup ? 'signup' : 'login';
-          this.finish(method, error, profile, authResult.idToken);
+          this.finish(method, error, profile, authResult);
         });
       });
 

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -3,9 +3,9 @@ import { auth } from '../constants'
 
 let fn = (obj={})=>{
   return Object.assign({}, {
-    profile: '',
-    token: '',
-    id: '',
+    profile: null,
+    token: null,
+    id: null,
     submitting: false,
     error: false,
     newUser: false


### PR DESCRIPTION
+ Stores complete authResult
+ Changed deprecated method

Stores complete authResult to be able to request via the _offline_access_  scope the refresh_token and then use it for better app flow.