### PR TITLE
Make compatible with create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ import { AuthComponent, AuthMiddlewares, AuthReducer } from 'react-redux-auth0'
 ### When starting your app, include the following environment variables:
 
 ```
-AUTH0_CLIENTID=client-id-string AUTH0_DOMAIN=domain npm your-start-command
+REACT_APP_AUTH0_CLIENTID=client-id-string REACT_APP_AUTH0_DOMAIN=domain npm your-start-command
 ```
 
 Include [Auth0](https://auth0.com/) from CDN in your template (believe me, you don't want to build it):
@@ -24,8 +24,8 @@ Make sure you have this webpack plugin so that webpack will compile in proper en
 ```
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(env),
-    'process.env.AUTH0_CLIENTID': JSON.stringify(AUTH0_CLIENTID),
-    'process.env.AUTH0_DOMAIN': JSON.stringify(AUTH0_DOMAIN)
+    'process.env.REACT_APP_AUTH0_CLIENTID': JSON.stringify(REACT_APP_AUTH0_CLIENTID),
+    'process.env.REACT_APP_AUTH0_DOMAIN': JSON.stringify(REACT_APP_AUTH0_DOMAIN)
   })
 ```
 
@@ -33,8 +33,8 @@ Make sure you have this webpack plugin so that webpack will compile in proper en
 
 ```
 const env = process.env.NODE_ENV;
-const AUTH0_CLIENTID = process.env.AUTH0_CLIENTID;
-const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
+const REACT_APP_AUTH0_CLIENTID = process.env.REACT_APP_AUTH0_CLIENTID;
+const REACT_APP_AUTH0_DOMAIN = process.env.REACT_APP_AUTH0_DOMAIN;
 ```
 
 # AuthComponent

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ import { AuthComponent, AuthMiddlewares, AuthReducer } from 'react-redux-auth0'
 ### When starting your app, include the following environment variables:
 
 ```
-REACT_APP_AUTH0_CLIENTID=client-id-string REACT_APP_AUTH0_DOMAIN=domain npm your-start-command
+AUTH0_CLIENTID=client-id-string AUTH0_DOMAIN=domain npm your-start-command
 ```
 
 Include [Auth0](https://auth0.com/) from CDN in your template (believe me, you don't want to build it):
@@ -24,8 +24,8 @@ Make sure you have this webpack plugin so that webpack will compile in proper en
 ```
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(env),
-    'process.env.REACT_APP_AUTH0_CLIENTID': JSON.stringify(REACT_APP_AUTH0_CLIENTID),
-    'process.env.REACT_APP_AUTH0_DOMAIN': JSON.stringify(REACT_APP_AUTH0_DOMAIN)
+    'process.env.AUTH0_CLIENTID': JSON.stringify(AUTH0_CLIENTID),
+    'process.env.AUTH0_DOMAIN': JSON.stringify(AUTH0_DOMAIN)
   })
 ```
 
@@ -33,9 +33,18 @@ Make sure you have this webpack plugin so that webpack will compile in proper en
 
 ```
 const env = process.env.NODE_ENV;
-const REACT_APP_AUTH0_CLIENTID = process.env.REACT_APP_AUTH0_CLIENTID;
-const REACT_APP_AUTH0_DOMAIN = process.env.REACT_APP_AUTH0_DOMAIN;
+const AUTH0_CLIENTID = process.env.AUTH0_CLIENTID;
+const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
 ```
+
+# Usage with CreateReactApp
+
+CreateReactApp has own webpack setup that is not easy to override, but it supports
+passing environment variables starting with `REACT_APP_` to application code.
+
+To make things easier for developers using CreateReactApp, we support
+`REACT_APP_AUTH0_CLIENTID` and `REACT_APP_AUTH0_DOMAIN` environment variables.
+If you need more information, please see [CreateReactApp readme, custom env variables](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables).
 
 # AuthComponent
 
@@ -60,4 +69,7 @@ The component will automatically return a `Logout` button when the user is authe
 ## Options
 
 `auth0`: auth0 lock customization options detailed here https://auth0.com/docs/libraries/lock/v10/customization
-`onAuthenticated (token, profile)`: A callback to receive when authentication has completed. 
+`onAuthenticated (token, profile)`: A callback to receive when authentication has completed.
+`credentials`: Optional object that contains `clientId` and `domain` properties.
+  You can use it if you have custom configuration setup not based on env variables, or if you
+  want to override credentials for just one component instance.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cacheable": "^0.2.9",
     "html-webpack-plugin": "^2.16.0",
     "namespaced-constants": "0.0.1",
+    "prop-types": "^15.5.10",
     "redux-modifiers": "0.0.5",
     "webpack-hot-middleware": "^2.10.0"
   },

--- a/src/component.js
+++ b/src/component.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { auth } from './constants'
 import { createAction as act } from 'redux-actions'
 import { connect } from 'react-redux'
@@ -159,7 +160,7 @@ AuthComponent.defaultProps = {
 }
 
 AuthComponent.propTypes = {
-  onAuthenticated: React.PropTypes.func
+  onAuthenticated: PropTypes.func
 };
 
 export default connect((state)=>{

--- a/src/component.js
+++ b/src/component.js
@@ -17,8 +17,8 @@ class AuthComponent extends React.Component {
   mountAuth0(options={}){
     try {
       this.lock = new Auth0Lock(
-        process.env.AUTH0_CLIENTID || 'Set process.env.AUTH0_CLIENTID', 
-        process.env.AUTH0_DOMAIN || 'Set process.env.AUTH0_DOMAIN', 
+        process.env.REACT_APP_AUTH0_CLIENTID || 'Set process.env.REACT_APP_AUTH0_CLIENTID', 
+        process.env.REACT_APP_AUTH0_DOMAIN || 'Set process.env.REACT_APP_AUTH0_DOMAIN', 
         Object.assign({}, options, this.props.auth0)
       );
 

--- a/src/component.js
+++ b/src/component.js
@@ -16,9 +16,16 @@ class AuthComponent extends React.Component {
 
   mountAuth0(options={}){
     try {
+      const { credentials } = this.props;
+      const { clientId, domain } = credentials;
+
+      if (!(clientId && domain)) {
+        throw('set process.env.AUTH0_CLIENTID and process.env.AUTH0_DOMAIN, ' +
+          'or pass `credentials` property to component.');
+      }
+
       this.lock = new Auth0Lock(
-        process.env.REACT_APP_AUTH0_CLIENTID || 'Set process.env.REACT_APP_AUTH0_CLIENTID', 
-        process.env.REACT_APP_AUTH0_DOMAIN || 'Set process.env.REACT_APP_AUTH0_DOMAIN', 
+        clientId, domain,
         Object.assign({}, options, this.props.auth0)
       );
 
@@ -137,13 +144,17 @@ class AuthComponent extends React.Component {
 }
 
 /*
- * Make redirect "false" 
+ * Make redirect "false"
  */
 AuthComponent.defaultProps = {
   auth0: {
     auth: {
       redirect: true
     }
+  },
+  credentials: {
+    clientId: process.env.AUTH0_CLIENTID || process.env.REACT_APP_AUTH0_CLIENTID,
+    domain: process.env.AUTH0_DOMAIN || process.env.REACT_APP_AUTH0_DOMAIN
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,8 @@ var path = require('path')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 
 const env = process.env.NODE_ENV;
-const AUTH0_CLIENTID = process.env.AUTH0_CLIENTID;
-const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
+const REACT_APP_AUTH0_CLIENTID = process.env.REACT_APP_AUTH0_CLIENTID;
+const REACT_APP_AUTH0_DOMAIN = process.env.REACT_APP_AUTH0_DOMAIN;
 
 var config = {
   module: {
@@ -21,8 +21,8 @@ var config = {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(env),
-      'process.env.AUTH0_CLIENTID': JSON.stringify(AUTH0_CLIENTID),
-      'process.env.AUTH0_DOMAIN': JSON.stringify(AUTH0_DOMAIN)
+      'process.env.REACT_APP_AUTH0_CLIENTID': JSON.stringify(REACT_APP_AUTH0_CLIENTID),
+      'process.env.REACT_APP_AUTH0_DOMAIN': JSON.stringify(REACT_APP_AUTH0_DOMAIN)
     })
   ]
 };


### PR DESCRIPTION
create-react-app maintainers are quite firm about not providing easy way to change Webpack configuration, but their script support passing env variables with names starting with `REACT_APP_`.

So what I did is I changed used env variable names to start with `REACT_APP_`.